### PR TITLE
Use responsive WebP images for better page performance.

### DIFF
--- a/src/components/ImageGridAnimated.jsx
+++ b/src/components/ImageGridAnimated.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useContext } from 'react';
 import PropTypes from 'prop-types';
-import Img from 'gatsby-image';
+import Image from 'gatsby-image';
 import styled, { keyframes } from 'styled-components';
 
 /* TODO
@@ -235,7 +235,7 @@ const ImageCell = ({ className, imageMaker, idx, deviceSize, style }) => {
   return (
     <div className={className} style={style}>
       <RelativeWrapper>
-        <Img fluid={imageMaker.mainImage.fluid} />
+        <Image fluid={imageMaker.mainImage.fluid} />
         <Overlay
           className="image-overlay"
           color={colorForIdx(idx, overlayColors)}

--- a/src/components/ImageGridAnimated.jsx
+++ b/src/components/ImageGridAnimated.jsx
@@ -324,10 +324,14 @@ const fadeIn = keyframes`
 
 // Styling the positioned cells with styled component classes was pretty expensive.
 // Let's try inline styles for the position + dimension attributes
+// TODO: Performance ideas: https://www.html5rocks.com/en/tutorials/speed/high-performance-animations/
+// We can try avoiding Layout recalculations with the following:
+// - Translate instead of top and left-based absolute positions
+// - Scale instead of width
 const PositionedImageCell = styled(ImageCell)`
   position: absolute;
   transition: top 0.5s ease 0s, left 0.5s ease 0s, width 0.5s ease 0s,
-    height 0.5s ease 0s, border-color 0s ease 0s;
+    height 0.5s ease 0s;
   animation: ${fadeIn} ease 1;
   animation-duration: 0.3s;
 `;

--- a/src/components/ImageGridAnimated.jsx
+++ b/src/components/ImageGridAnimated.jsx
@@ -324,10 +324,6 @@ const fadeIn = keyframes`
 
 // Styling the positioned cells with styled component classes was pretty expensive.
 // Let's try inline styles for the position + dimension attributes
-// TODO: Performance ideas: https://www.html5rocks.com/en/tutorials/speed/high-performance-animations/
-// We can try avoiding Layout recalculations with the following:
-// - Translate instead of top and left-based absolute positions
-// - Scale instead of width
 const PositionedImageCell = styled(ImageCell)`
   position: absolute;
   transition: top 0.5s ease 0s, left 0.5s ease 0s, width 0.5s ease 0s,
@@ -337,20 +333,6 @@ const PositionedImageCell = styled(ImageCell)`
 `;
 
 const ImageGridAnimated = ({ imageMakers, width }) => {
-  // TODO Remove this section after testing
-  // let copiedImageMakers = [];
-  // for (let i = 0; i < 10; i += 1) {
-    // copiedImageMakers = [...copiedImageMakers, ...imageMakers];
-  // }
-  // imageMakers = copiedImageMakers.map(({ node }, i) => {
-    // return {
-      // node: {
-        // ...node,
-        // id: `${node.id}${i}`,
-      // },
-    // };
-  // });
-
   const deviceSize = deviceSizeForWidth(width);
   const numCols = gridColumnsForBreakpoint[deviceSize];
   const cellWidth = Math.floor(width / numCols);

--- a/src/components/ImageGridAnimated.jsx
+++ b/src/components/ImageGridAnimated.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useContext } from 'react';
 import PropTypes from 'prop-types';
-import Image from 'gatsby-image';
+import Img from 'gatsby-image';
 import styled, { keyframes } from 'styled-components';
 
 /* TODO
@@ -40,6 +40,7 @@ const Grid = styled.div`
 
 const RelativeWrapper = styled.div`
   position: relative;
+  height: 100%;
   &:hover .image-overlay {
     opacity: 1;
   }
@@ -226,7 +227,14 @@ ImageMakerBlurb.propTypes = {
   deviceSize: PropTypes.string.isRequired,
 };
 
-const ImageCell = ({ className, imageMaker, idx, deviceSize, style }) => {
+const ImageCell = ({
+  className,
+  imageMaker,
+  idx,
+  deviceSize,
+  cellWidth,
+  style,
+}) => {
   const dispatch = useContext(GlobalDispatchContext);
   const state = useContext(GlobalStateContext); // TODO move this up to the grid level?
   const savedImageMakerIdSet = new Set(state.savedImageMakerIds);
@@ -235,7 +243,13 @@ const ImageCell = ({ className, imageMaker, idx, deviceSize, style }) => {
   return (
     <div className={className} style={style}>
       <RelativeWrapper>
-        <Image fluid={imageMaker.mainImage.fluid} />
+        <Img
+          fluid={{
+            ...imageMaker.mainImage.fluid,
+            sizes: `${cellWidth}px`, // Explicitly control the source size
+          }}
+          alt={imageMaker.name}
+        />
         <Overlay
           className="image-overlay"
           color={colorForIdx(idx, overlayColors)}
@@ -296,6 +310,7 @@ ImageCell.propTypes = {
   imageMaker: PropTypes.object,
   idx: PropTypes.number,
   deviceSize: PropTypes.string,
+  cellWidth: PropTypes.number,
   style: PropTypes.object,
 };
 
@@ -315,9 +330,23 @@ const PositionedImageCell = styled(ImageCell)`
 `;
 
 const ImageGridAnimated = ({ imageMakers, width }) => {
+  // TODO Remove this section after testing
+  let copiedImageMakers = [];
+  for (let i = 0; i < 10; i += 1) {
+    copiedImageMakers = [...copiedImageMakers, ...imageMakers];
+  }
+  imageMakers = copiedImageMakers.map(({ node }, i) => {
+    return {
+      node: {
+        ...node,
+        id: `${node.id}${i}`,
+      },
+    };
+  });
+
   const deviceSize = deviceSizeForWidth(width);
   const numCols = gridColumnsForBreakpoint[deviceSize];
-  const cellWidth = width / numCols;
+  const cellWidth = Math.floor(width / numCols);
   const numRows = Math.ceil(imageMakers.length / numCols);
   const height = numRows * cellWidth;
   return (
@@ -332,6 +361,7 @@ const ImageGridAnimated = ({ imageMakers, width }) => {
             idx={i}
             bottomBorderColor={colorForIdx(gridRow, gridLineColors)}
             deviceSize={deviceSize}
+            cellWidth={cellWidth}
             // Doing inline style instead of styled components here because this was generating
             // so many css classes when resizing and noticably hurting performance
             style={{

--- a/src/components/ImageGridAnimated.jsx
+++ b/src/components/ImageGridAnimated.jsx
@@ -331,18 +331,18 @@ const PositionedImageCell = styled(ImageCell)`
 
 const ImageGridAnimated = ({ imageMakers, width }) => {
   // TODO Remove this section after testing
-  let copiedImageMakers = [];
-  for (let i = 0; i < 10; i += 1) {
-    copiedImageMakers = [...copiedImageMakers, ...imageMakers];
-  }
-  imageMakers = copiedImageMakers.map(({ node }, i) => {
-    return {
-      node: {
-        ...node,
-        id: `${node.id}${i}`,
-      },
-    };
-  });
+  // let copiedImageMakers = [];
+  // for (let i = 0; i < 10; i += 1) {
+    // copiedImageMakers = [...copiedImageMakers, ...imageMakers];
+  // }
+  // imageMakers = copiedImageMakers.map(({ node }, i) => {
+    // return {
+      // node: {
+        // ...node,
+        // id: `${node.id}${i}`,
+      // },
+    // };
+  // });
 
   const deviceSize = deviceSizeForWidth(width);
   const numCols = gridColumnsForBreakpoint[deviceSize];

--- a/src/components/ImageGridAnimated.jsx
+++ b/src/components/ImageGridAnimated.jsx
@@ -41,6 +41,7 @@ const Grid = styled.div`
 const RelativeWrapper = styled.div`
   position: relative;
   height: 100%;
+  overflow: hidden;
   &:hover .image-overlay {
     opacity: 1;
   }
@@ -248,6 +249,8 @@ const ImageCell = ({
             ...imageMaker.mainImage.fluid,
             sizes: `${cellWidth}px`, // Explicitly control the source size
           }}
+          objectFit="cover"
+          style={{ height: '100%' }}
           alt={imageMaker.name}
         />
         <Overlay

--- a/src/components/ImageGridAnimated.jsx
+++ b/src/components/ImageGridAnimated.jsx
@@ -100,8 +100,8 @@ const SavePill = ({
 }) => {
   const [hover, setHover] = useState(false);
   const colors = hover ? hoverColors : defaultColors;
-  // const fontSize = fontStyles.imageGridPill.size * fontScaleForDevice[deviceSize];
-  const fontSize = 4;
+  const fontSize =
+    fontStyles.imageGridPill.size * fontScaleForDevice[deviceSize];
 
   return (
     <Pill
@@ -141,8 +141,8 @@ const AnchorPill = ({ href, defaultColors, hoverColors, deviceSize }) => {
   // TODO I do this hover management in many components. refactor?
   const [hover, setHover] = useState(false);
   const colors = hover ? hoverColors : defaultColors;
-  // const fontSize = fontStyles.imageGridPill.size * fontScaleForDevice[deviceSize];
-  const fontSize = 4;
+  const fontSize =
+    fontStyles.imageGridPill.size * fontScaleForDevice[deviceSize];
 
   return (
     <div
@@ -217,10 +217,7 @@ const fontScaleForIMBlurb = {
 };
 
 const ImageMakerBlurb = ({ imageMaker, deviceSize }) => (
-  <Blurb fontSize={
-    // Math.ceil(27 * fontScaleForIMBlurb[deviceSize])
-    8
-  }>
+  <Blurb fontSize={Math.ceil(27 * fontScaleForIMBlurb[deviceSize])}>
     {`${imageMaker.name} is`}
     {categorySentence(imageMaker.categories)}.
   </Blurb>
@@ -333,41 +330,37 @@ const fadeIn = keyframes`
 // - Scale instead of width
 const PositionedImageCell = styled(ImageCell)`
   position: absolute;
-  transition: transform 0.5s ease 0s;
+  transition: top 0.5s ease 0s, left 0.5s ease 0s, width 0.5s ease 0s,
+    height 0.5s ease 0s;
   animation: ${fadeIn} ease 1;
   animation-duration: 0.3s;
 `;
 
 const ImageGridAnimated = ({ imageMakers, width }) => {
   // TODO Remove this section after testing
-  let copiedImageMakers = [];
-  for (let i = 0; i < 10; i += 1) {
-    copiedImageMakers = [...copiedImageMakers, ...imageMakers];
-  }
-  imageMakers = copiedImageMakers.map(({ node }, i) => {
-    return {
-      node: {
-        ...node,
-        id: `${node.id}${i}`,
-      },
-    };
-  });
+  // let copiedImageMakers = [];
+  // for (let i = 0; i < 10; i += 1) {
+    // copiedImageMakers = [...copiedImageMakers, ...imageMakers];
+  // }
+  // imageMakers = copiedImageMakers.map(({ node }, i) => {
+    // return {
+      // node: {
+        // ...node,
+        // id: `${node.id}${i}`,
+      // },
+    // };
+  // });
 
   const deviceSize = deviceSizeForWidth(width);
   const numCols = gridColumnsForBreakpoint[deviceSize];
-  // const cellWidth = Math.floor(width / numCols);
-  const baseCellWidth = 100;
-  const targetCellWidth = width / numCols;
-  const cellScale = targetCellWidth / baseCellWidth;
+  const cellWidth = Math.floor(width / numCols);
   const numRows = Math.ceil(imageMakers.length / numCols);
-  const height = numRows * targetCellWidth;
+  const height = numRows * cellWidth;
   return (
     <Grid numImageMakers={imageMakers.length} height={height}>
       {imageMakers.map(({ node }, i) => {
         const gridCol = i % numCols;
         const gridRow = Math.floor(i / numCols);
-        const transform = `scale(${cellScale}) translate(${gridCol * baseCellWidth}px, ${gridRow * baseCellWidth}px)`;
-        console.log('transform', transform);
         return (
           <PositionedImageCell
             imageMaker={node}
@@ -375,19 +368,19 @@ const ImageGridAnimated = ({ imageMakers, width }) => {
             idx={i}
             bottomBorderColor={colorForIdx(gridRow, gridLineColors)}
             deviceSize={deviceSize}
-            cellWidth={targetCellWidth}
+            cellWidth={cellWidth}
             // Doing inline style instead of styled components here because this was generating
             // so many css classes when resizing and noticably hurting performance
             style={{
-              // top: gridRow * cellWidth,
-              // left: gridCol * cellWidth,
-              transformOrigin: 'top left',
-              transform: `${transform}`,
-              width: `${baseCellWidth}px`,
-              // width: cellWidth - 2,
-              // height: cellWidth - 2,
-              // borderRight: `2px solid ${colorForIdx(gridCol, gridLineColors)}`,
-              // boxShadow: `${colorForIdx(gridRow, gridLineColors)} 0px 2px 0px 0px`,
+              top: gridRow * cellWidth,
+              left: gridCol * cellWidth,
+              width: cellWidth - 2,
+              height: cellWidth - 2,
+              borderRight: `2px solid ${colorForIdx(gridCol, gridLineColors)}`,
+              boxShadow: `${colorForIdx(
+                gridRow,
+                gridLineColors
+              )} 0px 2px 0px 0px`,
             }}
           />
         );

--- a/src/components/ImageGridAnimated.jsx
+++ b/src/components/ImageGridAnimated.jsx
@@ -100,8 +100,8 @@ const SavePill = ({
 }) => {
   const [hover, setHover] = useState(false);
   const colors = hover ? hoverColors : defaultColors;
-  const fontSize =
-    fontStyles.imageGridPill.size * fontScaleForDevice[deviceSize];
+  // const fontSize = fontStyles.imageGridPill.size * fontScaleForDevice[deviceSize];
+  const fontSize = 4;
 
   return (
     <Pill
@@ -141,8 +141,8 @@ const AnchorPill = ({ href, defaultColors, hoverColors, deviceSize }) => {
   // TODO I do this hover management in many components. refactor?
   const [hover, setHover] = useState(false);
   const colors = hover ? hoverColors : defaultColors;
-  const fontSize =
-    fontStyles.imageGridPill.size * fontScaleForDevice[deviceSize];
+  // const fontSize = fontStyles.imageGridPill.size * fontScaleForDevice[deviceSize];
+  const fontSize = 4;
 
   return (
     <div
@@ -217,7 +217,10 @@ const fontScaleForIMBlurb = {
 };
 
 const ImageMakerBlurb = ({ imageMaker, deviceSize }) => (
-  <Blurb fontSize={Math.ceil(27 * fontScaleForIMBlurb[deviceSize])}>
+  <Blurb fontSize={
+    // Math.ceil(27 * fontScaleForIMBlurb[deviceSize])
+    8
+  }>
     {`${imageMaker.name} is`}
     {categorySentence(imageMaker.categories)}.
   </Blurb>
@@ -330,37 +333,41 @@ const fadeIn = keyframes`
 // - Scale instead of width
 const PositionedImageCell = styled(ImageCell)`
   position: absolute;
-  transition: top 0.5s ease 0s, left 0.5s ease 0s, width 0.5s ease 0s,
-    height 0.5s ease 0s;
+  transition: transform 0.5s ease 0s;
   animation: ${fadeIn} ease 1;
   animation-duration: 0.3s;
 `;
 
 const ImageGridAnimated = ({ imageMakers, width }) => {
   // TODO Remove this section after testing
-  // let copiedImageMakers = [];
-  // for (let i = 0; i < 10; i += 1) {
-    // copiedImageMakers = [...copiedImageMakers, ...imageMakers];
-  // }
-  // imageMakers = copiedImageMakers.map(({ node }, i) => {
-    // return {
-      // node: {
-        // ...node,
-        // id: `${node.id}${i}`,
-      // },
-    // };
-  // });
+  let copiedImageMakers = [];
+  for (let i = 0; i < 10; i += 1) {
+    copiedImageMakers = [...copiedImageMakers, ...imageMakers];
+  }
+  imageMakers = copiedImageMakers.map(({ node }, i) => {
+    return {
+      node: {
+        ...node,
+        id: `${node.id}${i}`,
+      },
+    };
+  });
 
   const deviceSize = deviceSizeForWidth(width);
   const numCols = gridColumnsForBreakpoint[deviceSize];
-  const cellWidth = Math.floor(width / numCols);
+  // const cellWidth = Math.floor(width / numCols);
+  const baseCellWidth = 100;
+  const targetCellWidth = width / numCols;
+  const cellScale = targetCellWidth / baseCellWidth;
   const numRows = Math.ceil(imageMakers.length / numCols);
-  const height = numRows * cellWidth;
+  const height = numRows * targetCellWidth;
   return (
     <Grid numImageMakers={imageMakers.length} height={height}>
       {imageMakers.map(({ node }, i) => {
         const gridCol = i % numCols;
         const gridRow = Math.floor(i / numCols);
+        const transform = `scale(${cellScale}) translate(${gridCol * baseCellWidth}px, ${gridRow * baseCellWidth}px)`;
+        console.log('transform', transform);
         return (
           <PositionedImageCell
             imageMaker={node}
@@ -368,19 +375,19 @@ const ImageGridAnimated = ({ imageMakers, width }) => {
             idx={i}
             bottomBorderColor={colorForIdx(gridRow, gridLineColors)}
             deviceSize={deviceSize}
-            cellWidth={cellWidth}
+            cellWidth={targetCellWidth}
             // Doing inline style instead of styled components here because this was generating
             // so many css classes when resizing and noticably hurting performance
             style={{
-              top: gridRow * cellWidth,
-              left: gridCol * cellWidth,
-              width: cellWidth - 2,
-              height: cellWidth - 2,
-              borderRight: `2px solid ${colorForIdx(gridCol, gridLineColors)}`,
-              boxShadow: `${colorForIdx(
-                gridRow,
-                gridLineColors
-              )} 0px 2px 0px 0px`,
+              // top: gridRow * cellWidth,
+              // left: gridCol * cellWidth,
+              transformOrigin: 'top left',
+              transform: `${transform}`,
+              width: `${baseCellWidth}px`,
+              // width: cellWidth - 2,
+              // height: cellWidth - 2,
+              // borderRight: `2px solid ${colorForIdx(gridCol, gridLineColors)}`,
+              // boxShadow: `${colorForIdx(gridRow, gridLineColors)} 0px 2px 0px 0px`,
             }}
           />
         );

--- a/src/components/Layout.jsx
+++ b/src/components/Layout.jsx
@@ -1,7 +1,8 @@
-import React, { useState, useLayoutEffect } from 'react';
+import React, { useState, useLayoutEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import _debounce from 'lodash.debounce';
+import _throttle from 'lodash.throttle';
 
 import Header from './Header';
 import Footer from './Footer';
@@ -58,9 +59,9 @@ const Layout = ({
   // viewport-size and scroll calculations, event listeners, and setting custom
   // CSS properties for use with transitions (to produce CSS transitions animations
   // without re-renders).
-  const containerRef = React.createRef();
-  const overflowableRef = React.createRef();
-  const logoRef = React.createRef();
+  const containerRef = useRef(null);
+  const overflowableRef = useRef(null);
+  const logoRef = useRef(null);
 
   // Calculated viewport / DOM measurements
   const [width, setWidth] = useState();
@@ -98,9 +99,10 @@ const Layout = ({
     window.addEventListener('resize', debouncedSetDimensions);
 
     // Scroll events
+    const throttledSetLogoScale = _throttle(setLogoScaleCSSVariable, 10);
     overflowableRef.current?.addEventListener(
       'scroll',
-      setLogoScaleCSSVariable,
+      throttledSetLogoScale,
       {
         passive: true,
       }
@@ -111,7 +113,7 @@ const Layout = ({
       window.removeEventListener('resize', debouncedSetDimensions);
       overflowableRef.current?.removeEventListener(
         'scroll',
-        setLogoScaleCSSVariable
+        throttledSetLogoScale,
       );
     };
   });

--- a/src/components/Logo.jsx
+++ b/src/components/Logo.jsx
@@ -39,7 +39,7 @@ const LogoWrapper = styled.div`
   ${props => `--initPadding: ${props.initPadding}px;`}
   width: calc(var(--logoScale, 1) * var(--initWidth));
   padding: calc(var(--logoScale, 1) * var(--initPadding));
-  transition: width 0.35s, height 0.35s, padding 0.35s;
+  transition: width 0.15s, height 0.15s, padding 0.15s;
 `;
 
 const Logo = ({ width, logoRef }) => {

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -92,7 +92,7 @@ export const query = graphql`
             bio
           }
           mainImage {
-            fluid(maxWidth: 700, maxHeight: 700) {
+            fluid {
               ...GatsbyContentfulFluid_withWebp
             }
           }

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -93,7 +93,7 @@ export const query = graphql`
           }
           mainImage {
             fluid(maxWidth: 700, maxHeight: 700) {
-              ...GatsbyContentfulFluid
+              ...GatsbyContentfulFluid_withWebp
             }
           }
           categories {

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -92,7 +92,7 @@ export const query = graphql`
             bio
           }
           mainImage {
-            fluid {
+            fluid(maxWidth: 700, maxHeight: 700) {
               ...GatsbyContentfulFluid_withWebp
             }
           }


### PR DESCRIPTION
# Changes

Improve image grid index page perfomance by responsively loading appropriate size images, and better-compressed WebP.

Some useful references:

- https://alexasteinbruck.medium.com/understanding-gatsby-image-part-3-controlling-sizes-breakpoints-and-styling-dfe92d0d10f4
- https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#attr-sizes

# Not in this PR

I initially wanted to make this more of a wholistic performance improvement of the image grid animation. I tried to do so by converting the image positioning and animation logic **from** a absolute-position with top and left properties approach **over to** scale and translate transformations approach, which [I've read is more efficient in the browser](https://www.html5rocks.com/en/tutorials/speed/high-performance-animations/).

The [proof of concept](https://github.com/domoench/psxyz/pull/41/commits/0547c122b396202a5ac6e9ffe2269a699d24b6a0) did work, but didn't show any clear performance improvement. That could be because I didn't fully follow through (there was a lot more work to fully commit to the new approach). But I decided not to keep pursuing it for now, because it's probably not practical to scale this animation up to 400+ grid cells anyway - as no one can see that many cells at once. We'll need a whole new approach long term (probably one where we only show and animate a subset of imagemakers, not all of them).
